### PR TITLE
fix(gatsby-plugin-sitemap): add url to metadata

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,7 @@
 module.exports = {
   siteMetadata: {
-    title: "Uridge Gatsby ",
+    title: "Robert Uridge",
+    siteUrl: `https://www.uridge.com`,
   },
   plugins: [
     "gatsby-plugin-gatsby-cloud",


### PR DESCRIPTION
<img width="759" alt="Screenshot 2021-05-13 at 15 46 51" src="https://user-images.githubusercontent.com/856071/118095362-8fc63d00-b402-11eb-89b5-40843f252a09.png">
